### PR TITLE
Remove `preferGlobal` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "version": "0.3.1",
   "main": "./lib/marked.js",
   "man": "./man/marked.1",
-  "preferGlobal": true,
   "repository": "git://github.com/LinuxBasic/react-marked.git",
   "homepage": "https://github.com/LinuxBasic/react-marked",
   "bugs": { "url": "https://github.com/LinuxBasic/react-marked/issues" },


### PR DESCRIPTION
This removes the warning from `npm` when installing..