### PR TITLE
React warning issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,10 @@ cd marked/
 node test
 ```
 
+### Known Issues
+
+* Elements created currently trigger the react-warning-keys warning as of React 0.15.1: ["Warning: Each child in an array or iterator should have a unique "key" prop."](https://fb.me/react-warning-keys)
+
 ### Contribution and License Agreement
 
 If you contribute code to this project, you are implicitly allowing your code


### PR DESCRIPTION
Why don't you have issues enabled for your repository? Since you made a module on npm with a rather "obvious" name for its purpose, and it seems that you have updated it relatively recently, it would be nice if you could either enable issues or put an email on your profile. That way people like myself who find an important but easily fixable issue - but have no time to figure out your code and fix it on their own - would at least be able to let you know about it.