### PR TITLE
Fix childrend typo so as to enable List

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -791,6 +791,10 @@
         return React.DOM.p(null,text);
     };
 
+    Renderer.prototype.span = function (text) {
+        return React.DOM.span(null,text);
+    };
+
     Renderer.prototype.table = function (header, body) {
         return React.DOM.table(null,
             React.DOM.thead({children:header}),
@@ -1039,11 +1043,11 @@
             }
             case 'paragraph':
             {
-                return this.renderer.paragraph(this.inline.output(this.token.text));
+                return this.renderer.span(this.inline.output(this.token.text));
             }
             case 'text':
             {
-                return this.renderer.paragraph(this.parseText());
+                return this.renderer.span(this.parseText());
             }
         }
     };
@@ -1054,11 +1058,11 @@
 
     function escape(html, encode) {
         return html
-            .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+            .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '\u0026')
+            .replace(/</g, '\u003C')
+            .replace(/>/g, '\u003E')
+            .replace(/"/g, '\u0022')
+            .replace(/'/g, '\u0027');
     }
 
     function unescape(html) {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -780,11 +780,11 @@
 
     Renderer.prototype.list = function (body, ordered) {
         var type = ordered ? 'ol' : 'ul';
-        return React.DOM[type]({childrend:body});
+        return React.DOM[type]({children:body});
     };
 
     Renderer.prototype.listitem = function (text) {
-        return React.DOM.li({childrend:text});
+        return React.DOM.li({children:text});
     };
 
     Renderer.prototype.paragraph = function (text) {
@@ -793,19 +793,19 @@
 
     Renderer.prototype.table = function (header, body) {
         return React.DOM.table(null,
-            React.DOM.thead({childrend:header}),
-            React.DOM.tbody({childrend:body})
+            React.DOM.thead({children:header}),
+            React.DOM.tbody({children:body})
         );
     };
 
     Renderer.prototype.tablerow = function (content) {
-        return React.DOM.tr({childrend:content});
+        return React.DOM.tr({children:content});
     };
 
     Renderer.prototype.tablecell = function (content, flags) {
         var type = flags.header ? 'th' : 'td';
         var props = {
-            childrend:content
+            children:content
         }
         if(flags.align){
             props.style.textAlign = flags.align


### PR DESCRIPTION
I notice the spelling for `children` in li, ol, ul is incorrect, which prevent the rendering of list.   
To fix this problem, simply replace all `childrend` to `children`. 